### PR TITLE
fully qualify paths used for gsettings binary

### DIFF
--- a/manifests/gsettings.pp
+++ b/manifests/gsettings.pp
@@ -44,13 +44,13 @@ define gnome::gsettings(
 
   $command = $list_append ? {
     # I think this commands only work when there is and X session running
-    true  => "gsettings set ${schema} ${key} \"`gsettings get ${schema} ${key} | sed s/.$//`, ${prep_value}]\"",
-    false => "gsettings set ${schema} ${key} \"${prep_value}\"",
+    true  => "/usr/bin/gsettings set ${schema} ${key} \"`gsettings get ${schema} ${key} | sed s/.$//`, ${prep_value}]\"",
+    false => "/usr/bin/gsettings set ${schema} ${key} \"${prep_value}\"",
   }
 
   exec {"set ${key} on user ${user} to ${prep_value}":
     command     => $command,
-    unless      => "gsettings get ${schema} ${key} | grep -q \"${prep_value}\"",
+    unless      => "/usr/bin/gsettings get ${schema} ${key} | grep -q \"${prep_value}\"",
     user        => $user,
     environment => ['DISPLAY=:0'],
   }


### PR DESCRIPTION
Paths aren't qualified in the exec used to check or set gsettings keys, which leads to the following error:

```
err: Failed to apply catalog: Parameter unless failed on Exec[set focus-mode on user amoe to 'sloppy']: 'gsettings get org.gnome.desktop.wm.preferences focus-mode | grep -q "'sloppy'"' is not qualified and no path was specified. Please qualify the command or specify a path.
```

This just qualifies the paths used for the gsettings commands so that they succeed.

The same might also need to be done for the `gconf` define, although I have not done that change.

Commit assumes gsettings is in `/usr/bin`.  The `gconf` define already assumes this path in places, so I figured this was fine.
