### PR TITLE
remove non US-ASCII characters from manifest

### DIFF
--- a/manifests/gsettings.pp
+++ b/manifests/gsettings.pp
@@ -1,6 +1,6 @@
 # == Definition: gnome::gsettings
 #
-# Sets a configuration key in Gnome’s GSettings registry.
+# Sets a configuration key in Gnome's GSettings registry.
 #
 define gnome::gsettings(
   $schema,


### PR DESCRIPTION
Under some cirmunstances Puppet will fail catalog compilation if it finds
non-ASCII characters in comments, probably related to
https://projects.puppetlabs.com/issues/11303

Remove the single non-ASCII character in this module to prevent the issue.