### PR TITLE
adding schema to exec resource, to avoid dup declarations

### DIFF
--- a/manifests/gsettings.pp
+++ b/manifests/gsettings.pp
@@ -13,7 +13,7 @@ define gnome::gsettings(
     content => "[${schema}]\n  ${key} = ${value}\n",
   }
   ~>
-  exec { "change${key}":
+  exec { "change-${schema}-${key}":
     command     => "/usr/bin/glib-compile-schemas ${directory}",
     refreshonly => true,
   }


### PR DESCRIPTION
Current master creates duplicate resource errors when different schemas have the same key...
```
  gnome::gsettings { 'disable-name-topbar':
    schema => 'org.gnome.desktop.privacy',
    key    => 'show-full-name-in-top-bar',
    value  => 'false',
  }

  gnome::gsettings { 'disable-name-topbar-screensaver':
    schema => 'org.gnome.desktop.screensaver',
    key    => 'show-full-name-in-top-bar',
    value  => 'false',
  }
```
Corrected by changing the exec definition to 'schema-key' instead of simply 'key'.
