### PR TITLE
Add ability to run gsettings for a specific user

### DIFF
--- a/manifests/gsettings.pp
+++ b/manifests/gsettings.pp
@@ -8,13 +8,22 @@ define gnome::gsettings(
   $value,
   $directory = '/usr/share/glib-2.0/schemas',
   $priority  = '25',
+  $user = undef,
 ) {
-  file { "${directory}/${priority}_${name}.gschema.override":
-    content => "[${schema}]\n  ${key} = ${value}\n",
-  }
+  if ($user == undef) {
+    file { "${directory}/${priority}_${name}.gschema.override":
+      content => "[${schema}]\n  ${key} = ${value}\n",
+    }
 
-  ~> exec { "change-${schema}-${key}":
-    command     => "/usr/bin/glib-compile-schemas ${directory}",
-    refreshonly => true,
+    ~> exec { "change-${schema}-${key}":
+      command     => "/usr/bin/glib-compile-schemas ${directory}",
+      refreshonly => true,
+    }
+  } else {
+    exec { "change-${schema}-${key}":
+      command => "dbus-launch gsettings set ${schema} ${key} ${value}",
+      path    => '/usr/bin',
+      user    => $user,
+    }
   }
 }

--- a/spec/defines/gsettings_spec.rb
+++ b/spec/defines/gsettings_spec.rb
@@ -134,4 +134,22 @@ describe 'gnome::gsettings' do
     it { should compile.with_all_deps }
     it { should contain_file('/usr/share/glib-2.0/schemas/42_rspec.gschema.override') }
   end
+
+  context 'with user set to valud user <testuser>' do
+    let(:params) do
+      mandatory_params.merge({
+        :user => 'testuser',
+      })
+    end
+
+    it { should compile.with_all_deps }
+
+    it do
+      should contain_exec('change-org.rspec.testing-/desktop/gnome/rspec/testing').with({
+        'command' => "dbus-launch gsettings set org.rspec.testing /desktop/gnome/rspec/testing /usr/rspec/testing",
+        'path'    => '/usr/bin',
+        'user'    => 'testuser',
+      })
+    end
+  end
 end


### PR DESCRIPTION
Hi,

I've made this change to allow me to run gsettings to apply customizations for a specific user, was wondering if this is suitable to address issue https://github.com/camptocamp/puppet-gnome/issues/17.

Regards,
Adam